### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/syntax_checkers/python/codec.py
+++ b/syntax_checkers/python/codec.py
@@ -26,6 +26,6 @@ try:
 
     compile(text, argv[1], 'exec', 0, 1)
 except SyntaxError as err:
-    print('%s:%s:%s: %s' % (err.filename, err.lineno, err.offset, err.msg))
+    print('{0!s}:{1!s}:{2!s}: {3!s}'.format(err.filename, err.lineno, err.offset, err.msg))
 except Exception as err:
-    print('%s:%s:%s: %s' % (os.path.abspath(argv[1]), 1, 0, err))
+    print('{0!s}:{1!s}:{2!s}: {3!s}'.format(os.path.abspath(argv[1]), 1, 0, err))

--- a/syntax_checkers/python/compile.py
+++ b/syntax_checkers/python/compile.py
@@ -10,4 +10,4 @@ if len(argv) != 2:
 try:
     compile(open(argv[1]).read(), argv[1], 'exec', 0, 1)
 except SyntaxError as err:
-    print('%s:%s:%s: %s' % (err.filename, err.lineno, err.offset, err.msg))
+    print('{0!s}:{1!s}:{2!s}: {3!s}'.format(err.filename, err.lineno, err.offset, err.msg))


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:syntastic?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:syntastic?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
